### PR TITLE
This commit resolves the problem described in issue report #16. 

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -30,25 +30,25 @@
     <section>
       <div class="emails">
         <div class="eKN">
-          <a href="mailto: novichenko.konstantin@gmail.com" target="_blank"> <img src="images/Vector/mail_white.svg" alt="Email"
+          <a href="mailto: novichenko.konstantin@gmail.com" target="_blank"> <img src="images/mail_white.svg" alt="Email"
             width= "43.38" height= "42.31"></a>
           <p>Konstantin Novichenko</p>
         </div>
         
         <div class="eAB">
-          <a href="mailto: alba.bella@cix.csi.cuny.edu" target="_blank"> <img src="images/Vector/mail_white.svg" alt="Email"
+          <a href="mailto: alba.bella@cix.csi.cuny.edu" target="_blank"> <img src="images/mail_white.svg" alt="Email"
             width= "43.38" height= "42.31">	</a>
         <p>Alba Bella</p>
         </div>
         
         <div class="eRK">
-          <a href="mailto: rehangh8924@gmail.com" target="_blank"> <img src="images/Vector/mail_white.svg" alt="Email"
+          <a href="mailto: rehangh8924@gmail.com" target="_blank"> <img src="images/mail_white.svg" alt="Email"
             width= "43.38" height= "42.31">	</a>
           <p>Rehan Khan</p>
         </div>
         
         <div class="eMO">
-          <a href="mailto: mohammedothman7@cix.csi.cuny.edu" target="_blank"> <img src="images/Vector/mail_white.svg" alt="Email"
+          <a href="mailto: mohammedothman7@cix.csi.cuny.edu" target="_blank"> <img src="images/mail_white.svg" alt="Email"
             width= "43.38" height= "42.31">	</a>
           <p>Mohammed Othman</p>
         </div>


### PR DESCRIPTION
After deleting the 'Vector' folder in 'images' to resolve issue #11, 'contacts.html' lost the reference to the mail icon image. The path to that image had to be changed from 'images/Vector/mail_white.svg' to 'images/mail_white.svg' in lines 33, 39, 45, and 51.